### PR TITLE
fix panic cause by uninitialized pprofile.Profiles

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -25,7 +25,7 @@ func (s *frScraper) scrape(ctx context.Context) (pprofile.Profiles, error) {
 	}
 
 	var scrapeErrors []error
-	var profiles pprofile.Profiles
+	profiles := pprofile.NewProfiles()
 
 	for _, match := range matches {
 		f, err := os.Open(match)


### PR DESCRIPTION
Hello, i was just exploring around. for scrape, uninitialized pprofile.Profiles cause panic during MergeTo()